### PR TITLE
rewrite Twitter URLs too

### DIFF
--- a/unstatrack.py
+++ b/unstatrack.py
@@ -13,8 +13,9 @@ intents = discord.Intents.default()
 intents.message_content = True
 client = discord.Client(intents=intents)
 
-# Regular expression to match Instagram URLs
+# Regular expression to match Instagram and Twitter URLs
 instagram_url_pattern = re.compile(r'(https?://(?:www\.)?instagram\.com/[^\s]+)')
+twitter_url_pattern = re.compile(r'(https?://(?:www\.)?(twitter|x)\.com/[^\s]+)')
 
 @client.event
 async def on_ready():
@@ -41,6 +42,16 @@ async def on_message(message):
 
             # Reply with the modified URL
             await message.reply(f'itym {new_url}')
+
+    # Search for Twitter/X URLs in the message
+    match = twitter_url_pattern.search(message.content)
+    if match:
+        url = match.group(1)
+        parsed_url = urlparse(url)
+        new_url = urlunparse(parsed_url._replace(netloc='fixupx.com', query=''))
+
+        # Reply with the modified URL
+        await message.reply(f'itym {new_url}')
 
 # Run the bot with the token from the .env file
 client.run(TOKEN)


### PR DESCRIPTION
Strips the query params (which I don't think are ever useful) and rewrites to fixupx.com, which will unfurl more nicely in Slack/Discord.